### PR TITLE
Add Attribute project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>true</ImplicitUsings>
+        <LangVersion>LatestMajor</LangVersion>
+    </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+  </ItemGroup>
+</Project>

--- a/FastLogr.sln
+++ b/FastLogr.sln
@@ -9,6 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{5B5D37B2-1
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "example", "example", "{C278E4D6-B85F-4B22-997F-78DFDDB227F0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastLogr.Attributes", "src\FastLogr.Attributes\FastLogr.Attributes.csproj", "{ED514E60-2856-4902-B447-44450BD2CD87}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -16,5 +18,14 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{ED514E60-2856-4902-B447-44450BD2CD87} = {A9821A7F-FA78-4CBD-9AC5-DF9FE4AA88E5}
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ED514E60-2856-4902-B447-44450BD2CD87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED514E60-2856-4902-B447-44450BD2CD87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED514E60-2856-4902-B447-44450BD2CD87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED514E60-2856-4902-B447-44450BD2CD87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/FastLogr.Attributes/FastLogr.Attributes.csproj
+++ b/src/FastLogr.Attributes/FastLogr.Attributes.csproj
@@ -7,4 +7,8 @@
         <LangVersion>LatestMajor</LangVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    </ItemGroup>
+
 </Project>

--- a/src/FastLogr.Attributes/FastLogr.Attributes.csproj
+++ b/src/FastLogr.Attributes/FastLogr.Attributes.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>LatestMajor</LangVersion>
+    </PropertyGroup>
+
+</Project>

--- a/src/FastLogr.Attributes/LogMessageAttribute.cs
+++ b/src/FastLogr.Attributes/LogMessageAttribute.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+
+namespace FastLogr.Attributes;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class LogMessageAttribute : Attribute
+{
+    public string MessageTemplate { get; set; } = string.Empty;
+    public LogLevel LogLevel { get; set; } = LogLevel.Information;
+    public EventId EventId { get; set; } = new();
+}


### PR DESCRIPTION
Adds a project to store the attributes used by `FastLogr`.
Currently there only is the marker attribute for future source gen.