### PR TITLE
Switch from `develop` to `main` for nightly releases

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -55,7 +55,7 @@ jobs:
           path: ./src/${{ env.PROJECT_NAME }}/bin/Release/*.nupkg
   prerelease:
     needs: build
-    if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifact


### PR DESCRIPTION
Closes #7 